### PR TITLE
Add GO:0044419 to occurs_in

### DIFF
--- a/canto/annotation_ex_config/GO_BP_A_E_config
+++ b/canto/annotation_ex_config/GO_BP_A_E_config
@@ -39,6 +39,7 @@ GO:0034613-is_a(GO:0006886)	is_a	has_input	ProteinID	localizes		0,1	user
 GO:0043487	is_a	has_regulation_target	TranscriptID	stabilizes		0,1	user
 #GO:0043666	is_a	regulates_activity_of	ProteinID	regulates activity of		0,1	user
 GO:0043393	is_a	has_regulation_target	ProteinID	regulates binding between (add TWO, i.e. both binding partners)		0,2	user
+GO:0044419	is_a	occurs_in	GO:0110165	occurs at		0,1	user
 GO:0045185	is_a	has_input	ProteinID	maintains location of		0,1	user
 #GO:0045859	is_a	regulates_activity_of	ProteinID	regulates activity of		0,1	user
 GO:0050684	is_a	has_regulation_target	TranscriptID	regulates processing of		0,1	user


### PR DESCRIPTION
Closes #40 

This pull requests adds a new instance of the occurs_in extension, with the following configuration:

property | value
-- | --
**Domain ID** | GO:0044419
**Domain label** | interspecies interaction between organisms
**Subset relation** | is_a
**Extension relation** | occurs_in
**Range ID** | GO:0110165
**Range label** | cellular anatomical entity
**Canto display text** | occurs at
**Help text** |  
**Cardinality** | 0,1
**Role** | user

The change is needed to enable occurs_in on some annotations in PHI-Canto, so that we can export a valid GAF file.

See issue #40 for the relevant discussion.