### PR TITLE
Add pathogen-host response terms to 'involved in biological process'

### DIFF
--- a/canto/annotation_ex_config/GO_MF_A_E_config
+++ b/canto/annotation_ex_config/GO_MF_A_E_config
@@ -2,7 +2,7 @@ domain ID	subset relation	extension relation	range ID	Canto display text	Help te
 GO:0001653	is_a	has_substrate	ProteinID	binds ligand		0,1	user
 GO:0003674	is_a	happens_during	GO:0022403|GO:0033554|GO:0072690|GO:0044770	has function during		0,1	user
 GO:0003674	is_a	occurs_in	GO:0110165	active in	a cell part where the activity is observed	0,1	user
-GO:0003674	is_a	part_of	GO:0009987	involved in biological process		0,1	user
+GO:0003674	is_a	part_of	GO:0009987|GO:0045087|GO:0052200	involved in biological process		0,1	user
 GO:0003676	is_a	occurs_in	SO:0001411	binds region		0,1	user
 GO:0003682	is_a	occurs_in	SO:0001411	binds chromatin region		0,1	user
 GO:0003700	is_a	has_regulation_target	TranscriptID	regulates transcription of		0,1	user


### PR DESCRIPTION
This pull request adds the following terms to the range of the molecular function extension 'involved in biological process':

- innate immune response ([GO:0045087](https://www.ebi.ac.uk/ols/ontologies/go/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0045087))
- response to host defenses ([GO:0052200](https://www.ebi.ac.uk/ols/ontologies/go/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0052200))

This is needed to fix the following issue for PHI-Canto: https://github.com/pombase/canto/issues/2276

I understand that these terms shouldn't be visible in PomBase's version of Canto, due to taxon restrictions.