### PR TITLE
Add GO:0140418 to part_of extension

### DIFF
--- a/canto/annotation_ex_config/GO_MF_A_E_config
+++ b/canto/annotation_ex_config/GO_MF_A_E_config
@@ -5,7 +5,7 @@ GO:0044183	is_a	has_input	ProteinID	stabilizes		0,1	user
 GO:0001653	is_a	has_input	ProteinID	binds ligand		0,1	user
 GO:0003674	is_a	happens_during	GO:0022403|GO:0033554|GO:0072690|GO:0044770|GO:0051707	has function during		0,1	user
 GO:0003674	is_a	occurs_in	GO:0110165	physical location	a cell part where the activity is observed	0,1	user
-GO:0003674	is_a	part_of	GO:0009987|GO:0045087|GO:0052200	involved in biological process		0,1	user
+GO:0003674	is_a	part_of	GO:0009987|GO:0045087|GO:0052200|GO:0140418	involved in biological process		0,1	user
 GO:0003676	is_a	occurs_in	SO:0001411	binds region		0,1	user
 GO:0003682	is_a	occurs_in	SO:0001411	binds chromatin region		0,1	user
 GO:0003700	is_a	has_regulation_target	TranscriptID	regulates transcription of		0,1	user


### PR DESCRIPTION
This PR adds the term 'effector-mediated modulation of host process by symbiont' (GO:0140418) to the range of the 'involved in biological process' (part_of) extension on GO Molecular Function annotations.

PHI-base needs this term added for a curation session.

(See #95)